### PR TITLE
feat: grabbing user IP address logic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,12 @@
-import Image from "next/image";
+import IPDataTracker from "@/components/IPDataTracker";
 
 export default function Home() {
   return (
-    <main className="flex items-end">
-     <h1>Ip Address Tracker</h1>
+    <main className="flex justify-center w-full">
+      <div>
+        <h1>Ip Address Tracker</h1>
+        <IPDataTracker />
+      </div>
     </main>
   );
 }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,0 +1,11 @@
+import { headers } from "next/headers";
+
+export function getUserIp() {
+  const forwardedFor = headers().get("x-forwarded-for");
+
+  if (forwardedFor) {
+    return forwardedFor.split(",")[0];
+  }
+
+  return headers().get("x-real-ip");
+}

--- a/src/components/IPDataTracker.tsx
+++ b/src/components/IPDataTracker.tsx
@@ -1,0 +1,6 @@
+import { getUserIp } from "@/app/utils";
+
+export default async function IPDataTracker() {
+  const userIp = getUserIp();
+  return <p>{userIp}</p>;
+}


### PR DESCRIPTION
This PR adds grabbing user's IP address logic.

changes:
- added `getUserIp` utils function that leverages `next/headers` built-in method to grab user's IP address;
- a `IPDataTracker` component that currently grab and display user IP address.